### PR TITLE
Update warning catch to elminate bug where print() causes an error

### DIFF
--- a/R/enrich_path_stats.R
+++ b/R/enrich_path_stats.R
@@ -67,7 +67,7 @@ CalculateOraScore <- function(mSetObj=NA, nodeImp, method){
     endpoint <- "/pathwayora"
     call <- paste(base, endpoint, sep="")
     query_results <- httr::POST(call, body = toSend, encode= "json")
-    query_results_text <- content(query_results, "text", encoding = "UTF-8")
+    query_results_text <- content(query_results)
     query_results_json <- RJSONIO::fromJSON(query_results_text, flatten = TRUE)
     
     # parse json response from server to results

--- a/R/enrich_path_stats.R
+++ b/R/enrich_path_stats.R
@@ -68,7 +68,7 @@ CalculateOraScore <- function(mSetObj=NA, nodeImp, method){
     call <- paste(base, endpoint, sep="")
     query_results <- httr::POST(call, body = toSend, encode= "json")
     query_results_text <- httr::content(query_results,"text", encoding = "UTF-8")
-    query_results_json <- RJSONIO::fromJSON(query_results_text, flatten = TRUE)
+    query_results_json <- RJSONIO::fromJSON(str(query_results_text), flatten = TRUE)
     
     # parse json response from server to results
     oraDataRes <- do.call(rbind.data.frame, query_results_json$enrichRes)

--- a/R/enrich_path_stats.R
+++ b/R/enrich_path_stats.R
@@ -67,7 +67,7 @@ CalculateOraScore <- function(mSetObj=NA, nodeImp, method){
     endpoint <- "/pathwayora"
     call <- paste(base, endpoint, sep="")
     query_results <- httr::POST(call, body = toSend, encode= "json")
-    query_results_text <- httr::content(query_results)
+    query_results_text <- httr::content(query_results,"text", encoding = "UTF-8")
     query_results_json <- RJSONIO::fromJSON(query_results_text, flatten = TRUE)
     
     # parse json response from server to results

--- a/R/enrich_path_stats.R
+++ b/R/enrich_path_stats.R
@@ -68,7 +68,7 @@ CalculateOraScore <- function(mSetObj=NA, nodeImp, method){
     call <- paste(base, endpoint, sep="")
     query_results <- httr::POST(call, body = toSend, encode= "json")
     query_results_text <- httr::content(query_results,"text", encoding = "UTF-8")
-    query_results_json <- RJSONIO::fromJSON(str(query_results_text), flatten = TRUE)
+    query_results_json <- RJSONIO::fromJSON(query_results_text, flatten = TRUE)
     
     # parse json response from server to results
     oraDataRes <- do.call(rbind.data.frame, query_results_json$enrichRes)

--- a/R/enrich_path_stats.R
+++ b/R/enrich_path_stats.R
@@ -67,7 +67,7 @@ CalculateOraScore <- function(mSetObj=NA, nodeImp, method){
     endpoint <- "/pathwayora"
     call <- paste(base, endpoint, sep="")
     query_results <- httr::POST(call, body = toSend, encode= "json")
-    query_results_text <- content(query_results)
+    query_results_text <- content(query_results, "text")
     query_results_json <- RJSONIO::fromJSON(query_results_text, flatten = TRUE)
     
     # parse json response from server to results

--- a/R/enrich_path_stats.R
+++ b/R/enrich_path_stats.R
@@ -67,7 +67,7 @@ CalculateOraScore <- function(mSetObj=NA, nodeImp, method){
     endpoint <- "/pathwayora"
     call <- paste(base, endpoint, sep="")
     query_results <- httr::POST(call, body = toSend, encode= "json")
-    query_results_text <- content(query_results, "text")
+    query_results_text <- httr::content(query_results)
     query_results_json <- RJSONIO::fromJSON(query_results_text, flatten = TRUE)
     
     # parse json response from server to results

--- a/R/general_data_utils.R
+++ b/R/general_data_utils.R
@@ -197,7 +197,7 @@ InitDataObjects <- function(data.type, anal.type, paired=FALSE){
   }
 
   gene.sqlite.path <<- url.pre;
-  api.base <<- "api.metaboanalyst.ca" #"localhost:8987"
+  api.base <<- " http://api.metaboanalyst.ca" #"localhost:8987"
 
   print("MetaboAnalyst R objects initialized ...");
   return(.set.mSet(mSetObj));

--- a/R/general_data_utils.R
+++ b/R/general_data_utils.R
@@ -177,7 +177,7 @@ InitDataObjects <- function(data.type, anal.type, paired=FALSE){
   }
   
   # plotting required by all
-  Cairo::CairoFonts(regular="Arial:style=Regular",bold="Arial:style=Bold",italic="Arial:style=Italic",bolditalic = "Arial:style=Bold Italic",symbol = "Symbol")
+  # Cairo::CairoFonts(regular="Arial:style=Regular",bold="Arial:style=Bold",italic="Arial:style=Italic",bolditalic = "Arial:style=Bold Italic",symbol = "Symbol")
   
   # sqlite db path for gene annotation
   if(file.exists("/home/glassfish/sqlite/")){ #.on.public.web

--- a/R/general_data_utils.R
+++ b/R/general_data_utils.R
@@ -1270,7 +1270,7 @@ PlotCmpdSummary <- function(mSetObj=NA, cmpdNm, format="png", dpi=72, width=NA){
       tryCatch(
         {
           download.file(lib.url, destfile=filenm, method="curl")
-        }, warning = function(w){ print() },
+        }, warning = function(w){ print('warning in load') },
         error = function(e) {
           print("Download unsucceful. Ensure that curl is downloaded on your computer.")
           print("Attempting to re-try download using libcurl...")
@@ -1286,7 +1286,7 @@ PlotCmpdSummary <- function(mSetObj=NA, cmpdNm, format="png", dpi=72, width=NA){
     my.lib <- readRDS(lib.path); # this is a returned value, my.lib never called outside this function, should not be in global env.
     print("Loaded files from MetaboAnalyst web-server.")
   },
-  warning = function(w) { print() },
+  warning = function(w) { print('warning in load') },
   error = function(err) {
     print("Reading data unsuccessful, attempting to re-download file...")
     tryCatch(
@@ -1296,7 +1296,7 @@ PlotCmpdSummary <- function(mSetObj=NA, cmpdNm, format="png", dpi=72, width=NA){
         my.lib <- readRDS(lib.path);
         print("Loaded necessary files.")
       },
-      warning = function(w) { print() },
+      warning = function(w) { print('warning in load') },
       error = function(err) {
         print("Loading files from server unsuccessful. Ensure curl is downloaded on your computer.")
       }

--- a/R/general_data_utils.R
+++ b/R/general_data_utils.R
@@ -197,7 +197,7 @@ InitDataObjects <- function(data.type, anal.type, paired=FALSE){
   }
 
   gene.sqlite.path <<- url.pre;
-  api.base <<- " http://api.metaboanalyst.ca" #"localhost:8987"
+  api.base <<- "http://api.metaboanalyst.ca" #"localhost:8987"
 
   print("MetaboAnalyst R objects initialized ...");
   return(.set.mSet(mSetObj));

--- a/R/general_data_utils.R
+++ b/R/general_data_utils.R
@@ -1270,7 +1270,7 @@ PlotCmpdSummary <- function(mSetObj=NA, cmpdNm, format="png", dpi=72, width=NA){
       tryCatch(
         {
           download.file(lib.url, destfile=filenm, method="curl")
-        }, warning = function(w){ print('warning in load') },
+        }, warning = function(w){ print('warning in curl download') },
         error = function(e) {
           print("Download unsucceful. Ensure that curl is downloaded on your computer.")
           print("Attempting to re-try download using libcurl...")
@@ -1286,7 +1286,7 @@ PlotCmpdSummary <- function(mSetObj=NA, cmpdNm, format="png", dpi=72, width=NA){
     my.lib <- readRDS(lib.path); # this is a returned value, my.lib never called outside this function, should not be in global env.
     print("Loaded files from MetaboAnalyst web-server.")
   },
-  warning = function(w) { print('warning in load') },
+  warning = function(w) { print('warning in read') },
   error = function(err) {
     print("Reading data unsuccessful, attempting to re-download file...")
     tryCatch(
@@ -1296,7 +1296,7 @@ PlotCmpdSummary <- function(mSetObj=NA, cmpdNm, format="png", dpi=72, width=NA){
         my.lib <- readRDS(lib.path);
         print("Loaded necessary files.")
       },
-      warning = function(w) { print('warning in load') },
+      warning = function(w) { print('warning in final try again') },
       error = function(err) {
         print("Loading files from server unsuccessful. Ensure curl is downloaded on your computer.")
       }


### PR DESCRIPTION
This bug is particularly problematic for loading 'compound_db.rds'