### PR TITLE
Fix bug plots in enrichment analysis

### DIFF
--- a/R/enrich_graphics.R
+++ b/R/enrich_graphics.R
@@ -71,8 +71,7 @@ PlotQEA.MetSet<-function(mSetObj=NA, setNM, format="png", dpi=72, width=NA){
   }
   
   cls.vec <- as.factor(cls.vec);
-  lbl.vec <- as.factor(lbl.vec);
-  levels(lbl.vec) <- unique(lbl.vec); # make sure the same order as p value, rather by alphabetic
+  lbl.vec <- factor(lbl.vec, levels = unique(lbl.vec)); # make sure the same order as p value, rather by alphabetic
 
   num <- length(hit.cmpds);
   boxdata <- data.frame(Feature = lbl.vec, Abundance = conc.vec, Class = cls.vec)


### PR DESCRIPTION
See problem described in #152 
It seems as the problem was with the conversion of the metabolite labels `lbl.vec` from vector of characters to a factor vector.