### PR TITLE
fix t.test bug

### DIFF
--- a/R/general_norm_utils.R
+++ b/R/general_norm_utils.R
@@ -112,6 +112,12 @@ Normalization <- function(mSetObj=NA, rowNorm, transNorm, scaleNorm, ref=NULL, r
     }
     rownm<-"Normalization by sample-specific factor";
     data<-data/norm.vec;
+  }else if (rowNorm == "ProbNormT") {
+    ## PQN using "mean" as reference 
+    rownm <- "Normalization by Probabilistic Quotient Normalization without using a reference sample"
+    m <- t(data)
+    m <- m/apply(m/rowMeans(m, na.rm = TRUE), 2, median, na.rm = TRUE)
+    data <- t(m)
   }else{
     # nothing to do
     rownm<-"N/A";

--- a/R/stats_univariates.R
+++ b/R/stats_univariates.R
@@ -329,7 +329,7 @@ Ttests.Anal <- function(mSetObj=NA, nonpar=F, threshp=0.05, paired=FALSE, equal.
    inx.imp <- fdr.p <= threshp;
   # if there is no sig cmpds, it will be errors, need to improve
   
-    sig.num <- sum(inx.imp);
+    sig.num <- sum(inx.imp, na.rm = T);
     if(is.na(sig.num)){
     AddMsg(paste("No significant features were found."));
     return(0)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For Mac OS: In order to compile R for Mac OS, you need Xcode and GNU Fortran com
 
 R base with version > 3.6.1 is recommended. The compatibility of latest version (v4.0.0) is under evaluation. As for installation of package dependencies, there are two options:
 
+**Note: Option 1 went through well in the following process, so use it to get package dependencies.**
+
 **Option 1** 
 
 Enter the R function (metanr_packages) and then use the function. A printed message will appear informing you whether or not any R packages were installed.
@@ -56,22 +58,29 @@ metanr_packages <- function(){
 Usage of function:
 ```R
 metanr_packages()
+BiocManager::install("ctc")
+BiocManager::install("glasso")
+BiocManager::install("huge")
+BiocManager::install("ppcor")
 ```
 
-**Option 2** 
+~~Option 2~~
 
-Use the pacman R package (for those with >R 3.5.1). 
+~~Use the pacman R package (for those with >R 3.5.1).~~
 
-```R
-install.packages("pacman")
+~~R~~
+~~install.packages("pacman")~~
 
-library(pacman)
+~~library(pacman)~~
 
-pacman::p_load(c("impute", "pcaMethods", "globaltest", "GlobalAncova", "Rgraphviz", "preprocessCore", "genefilter", "SSPA", "sva", "limma", "KEGGgraph", "siggenes","BiocParallel", "MSnbase", "multtest","RBGL","edgeR","fgsea","httr","qs"))
-```
+~~pacman::p_load(c("impute", "pcaMethods", "globaltest", "GlobalAncova", "Rgraphviz", "preprocessCore", "genefilter", "SSPA", "sva", "limma", "KEGGgraph", "siggenes","BiocParallel", "MSnbase", "multtest","RBGL","edgeR","fgsea","httr","qs"))~~
+
+
 ### Step 2. Install the package
 
 MetaboAnalystR 3.0 is freely available from GitHub. The package documentation, including the vignettes for each module and user manual is available within the downloaded R package file. You can install the MetaboAnalylstR 3.0 via any of the three options: A) using the R package devtools, B) cloning the github, C) manually downloading the .tar.gz file. Note that the MetaboAnalystR 3.0 github will have the most up-to-date version of the package. 
+
+**Note: Leon recommand that you use the option A) ob B)(option A has been already tested in R version 3.6.3 local machine) to install the latest version of MetaboAnalystR from xlhd19980327/MetaboAnalystR(branch fix-bug) to get less bug.**
 
 #### Option A) Install the package directly from github using the *devtools* package. Open R and enter:
 
@@ -82,11 +91,11 @@ Due to issues with Latex, some users may find that they are only able to install
 install.packages("devtools")
 library(devtools)
 
-# Step 2: Install MetaboAnalystR with documentation
-devtools::install_github("xia-lab/MetaboAnalystR", build = TRUE, build_vignettes = TRUE, build_manual =T)
+# Step 2: Install MetaboAnalystR with documentation(recommanded)
+devtools::install_github("xlhd19980327/MetaboAnalystR", ref = "fix-bug", build = TRUE, build_vignettes = TRUE, build_manual =T)
 
 # Step 2: Install MetaboAnalystR without documentation
-devtools::install_github("xia-lab/MetaboAnalystR", build = TRUE, build_vignettes = FALSE)
+devtools::install_github("xlhd19980327/MetaboAnalystR", ref = "fix-bug", build = TRUE, build_vignettes = FALSE)
 
 ```
 
@@ -95,7 +104,7 @@ devtools::install_github("xia-lab/MetaboAnalystR", build = TRUE, build_vignettes
 The * must be replaced by what is actually downloaded and built.  
 
 ```R
-git clone https://github.com/xia-lab/MetaboAnalystR.git
+git clone -b fix-bug https://github.com/xlhd19980327/lipidIntegratedAnalysis.git
 R CMD build MetaboAnalystR
 R CMD INSTALL MetaboAnalystR_3.0.3.tar.gz
 


### PR DESCRIPTION
The Ttests.Anal function will render a error when the t.test encounter an error. That's because the inx.imp object(which is whether the feature is significantly changed) contains the NA value, and the sig.numt(which is the number of significant features) will sum the object and returns a NA, which will rise the error. So I just use the sum function argument "na.rm = T" to fix the bug. See the PR for more details.